### PR TITLE
Add live button linking to deployed site

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,12 @@
                 </a>
               </span>
               <span class="link-block">
+                <a href="https://repowise.netlify.app/" class="external-link button is-normal is-rounded is-dark" target="_blank">
+                  <span class="icon"><i class="fas fa-rocket"></i></span>
+                  <span>Live</span>
+                </a>
+              </span>
+              <span class="link-block">
                 <a href="#architecture" class="external-link button is-normal is-rounded is-dark">
                   <span class="icon"><i class="fas fa-diagram-project"></i></span>
                   <span>Architecture</span>


### PR DESCRIPTION
## Summary
- add a hero section button linking to the live RepoWise deployment on Netlify

## Testing
- not run (static content)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e510dd94832a830ed78691512e2d)