### PR TITLE
Reorder hero buttons to highlight live site

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,12 @@
           <div class="column has-text-centered">
             <div class="publication-links">
               <span class="link-block">
+                <a href="https://repowise.netlify.app/" class="external-link button is-normal is-rounded is-dark" target="_blank">
+                  <span class="icon"><i class="fas fa-rocket"></i></span>
+                  <span>Live</span>
+                </a>
+              </span>
+              <span class="link-block">
                 <a href="https://github.com/RepoWise/backend" class="external-link button is-normal is-rounded is-dark" target="_blank">
                   <span class="icon"><i class="fab fa-github"></i></span>
                   <span>Backend Code</span>
@@ -103,12 +109,6 @@
                 <a href="https://github.com/RepoWise/frontend" class="external-link button is-normal is-rounded is-dark" target="_blank">
                   <span class="icon"><i class="fab fa-github"></i></span>
                   <span>Frontend Code</span>
-                </a>
-              </span>
-              <span class="link-block">
-                <a href="https://repowise.netlify.app/" class="external-link button is-normal is-rounded is-dark" target="_blank">
-                  <span class="icon"><i class="fas fa-rocket"></i></span>
-                  <span>Live</span>
                 </a>
               </span>
               <span class="link-block">


### PR DESCRIPTION
## Summary
- reorder the hero call-to-action buttons so the Live link appears before the code repositories

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133d2590a4832ab646f080be6a6af8)