### PR TITLE
Add governance documentation and site link

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,46 @@
+# RepoWise Governance
+
+This document defines how RepoWise is stewarded, who is responsible for specific areas of the project, and how decisions are reached. The goal is to keep the project transparent, predictable, and welcoming for contributors of all backgrounds.
+
+## Roles
+
+- **Steering Committee** – Sets the long-term strategy for RepoWise, curates the roadmap, and approves policy changes. Membership is by invitation from the existing committee and is reviewed annually.
+- **Core Maintainers** – Own day-to-day development and releases for specific components (frontend, backend, documentation, community tooling). Maintainers merge pull requests, triage issues, and ensure that the project standards are upheld.
+- **Contributors** – Anyone who submits issues, patches, documentation updates, or feedback. Contributors help test releases, propose new ideas, and can graduate to maintainer status based on sustained impact.
+- **Community Advocates** – Volunteers who focus on outreach, onboarding, and facilitation of community discussions. They help shepherd new contributors and ensure inclusive participation.
+
+## Responsibilities
+
+- **Steering Committee**
+  - Publish and maintain the project charter and multi-quarter roadmap.
+  - Ratify governance or licensing changes.
+  - Resolve deadlocks escalated from the maintainer team.
+- **Core Maintainers**
+  - Review and merge pull requests following the contribution guidelines.
+  - Own release automation, documentation quality, and incident response.
+  - Ensure that issues are categorized, prioritized, and assigned appropriately.
+- **Contributors**
+  - Follow the code of conduct and contribution guidelines.
+  - Provide actionable feedback through issues, discussions, or review comments.
+  - Participate in testing and documentation improvements.
+- **Community Advocates**
+  - Facilitate community calls, office hours, or async forums.
+  - Identify and mentor new contributors.
+  - Surface community concerns to the Steering Committee.
+
+## Decision-Making Process
+
+1. **Proposal** – Any contributor can open a GitHub issue or RFC describing the desired change. Proposals must outline the problem, the solution, and measurable impact.
+2. **Discussion** – Maintainers and the community provide feedback within one week for routine changes and two weeks for substantial changes (e.g., API, UX, or governance updates).
+3. **Approval** – Decisions are made by **lazy consensus** among the responsible maintainers. Silence after the review window implies approval. For cross-cutting changes, at least two maintainers from different components must sign off.
+4. **Escalation** – If consensus is not reached, the topic is escalated to the Steering Committee, which delivers a binding decision within one additional week.
+
+## Conflict Resolution
+
+1. **Direct Dialogue** – Parties involved in a disagreement should first seek resolution through respectful, private discussion (e.g., GitHub discussions, project chat). Document the outcome in the relevant issue or pull request.
+2. **Maintainer Mediation** – If direct dialogue fails, request mediation from a neutral maintainer or community advocate. They will summarize perspectives, propose compromise paths, and ensure code of conduct compliance.
+3. **Steering Committee Review** – Persistent conflicts, code of conduct violations, or governance disputes are escalated to the Steering Committee. The committee may request additional context, pause related work, or issue a binding decision. In severe cases, they can revoke repository access or membership.
+
+## Amendments
+
+This governance document is reviewed every six months. Amendments require a proposal, a two-week community comment period, and Steering Committee approval.

--- a/index.html
+++ b/index.html
@@ -166,6 +166,12 @@
                   <span>Architecture</span>
                 </a>
               </span>
+              <span class="link-block">
+                <a href="GOVERNANCE.md" class="external-link button is-normal is-rounded is-dark" target="_blank">
+                  <span class="icon"><i class="fas fa-gavel"></i></span>
+                  <span>Governance</span>
+                </a>
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a GOVERNANCE.md document that explains roles, responsibilities, decision-making, and conflict-resolution processes
- expose the governance document directly on the landing page with a dedicated button so visitors can reach it easily

## Testing
- not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cecaae5b0832aad7fd88edc511ce7)