### PR TITLE
Add view tracking using configurable API base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL for the RepoWise backend API used for view tracking
+VITE_API_BASE_URL=https://your-domain.example

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Thumbs.db
 *.tmp
 *.temp
 *.bak
+.env
+.env.local

--- a/index.html
+++ b/index.html
@@ -1003,6 +1003,15 @@ npm run dev</code></pre>
   </div>
 </section>
 
+<section class="section" id="repowise-views">
+  <div class="container is-max-desktop">
+    <div class="box has-text-centered">
+      <h2 class="title is-5" style="margin-bottom: 0.5em;">RepoWise Views</h2>
+      <p class="is-size-5">RepoWise Views: <span id="view-count" class="tag is-link is-light is-medium">...</span></p>
+    </div>
+  </div>
+</section>
+
 <footer class="footer">
   <div class="container">
     <div class="content has-text-centered">
@@ -1015,6 +1024,8 @@ npm run dev</code></pre>
     </div>
   </div>
 </footer>
+
+<script src="./static/js/view-counter.js"></script>
 
 </body>
 </html>

--- a/static/js/view-counter.js
+++ b/static/js/view-counter.js
@@ -3,6 +3,8 @@ const PLACEHOLDER_BASES = new Set([
   'http://your-backend-domain.com',
   'https://example.com',
   'http://example.com',
+  'https://your-domain.example',
+  'http://your-domain.example',
   'null'
 ]);
 
@@ -15,7 +17,26 @@ function normalizeBase(base) {
   return base.trim().replace(/\/+$/, '');
 }
 
-function collectConfiguredBases() {
+async function loadEnvApiBase() {
+  try {
+    const response = await fetch('.env', { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`.env fetch failed with status ${response.status}`);
+    }
+
+    const envText = await response.text();
+    const match = envText.match(/^VITE_API_BASE_URL\s*=\s*(.+)$/m);
+    if (match && match[1]) {
+      return normalizeBase(match[1]);
+    }
+  } catch (error) {
+    console.warn('Unable to load VITE_API_BASE_URL from .env', error);
+  }
+
+  return '';
+}
+
+async function collectConfiguredBases() {
   const bases = [];
 
   const addBase = (value) => {
@@ -28,6 +49,9 @@ function collectConfiguredBases() {
     }
     bases.push(normalizeBase(trimmed));
   };
+
+  const envBase = await loadEnvApiBase();
+  addBase(envBase);
 
   if (scriptElement && scriptElement.dataset) {
     addBase(scriptElement.dataset.apiBase);
@@ -51,7 +75,7 @@ function collectConfiguredBases() {
   return uniqueBases;
 }
 
-const API_BASES = collectConfiguredBases();
+const API_BASES_PROMISE = collectConfiguredBases();
 
 function joinUrl(base, path) {
   if (!base) {
@@ -66,7 +90,9 @@ function joinUrl(base, path) {
 async function fetchWithFallback(path, options) {
   let lastError = null;
 
-  for (const base of API_BASES) {
+  const apiBases = await API_BASES_PROMISE;
+
+  for (const base of apiBases) {
     const url = joinUrl(base, path);
 
     try {


### PR DESCRIPTION
## Summary
- add a RepoWise Views section on the dashboard that records and displays view counts
- wire the view counter to use the backend API base URL from a configurable .env value with fallbacks
- document the required environment variable and ignore local .env files

## Testing
- Not run (not provided)