### PR TITLE
Separate acknowledgments and contact sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,22 +970,28 @@ npm run dev</code></pre>
   </div>
 </section>
 
-<section class="section" id="contact-acknowledgments">
+<section class="section" id="acknowledgments">
   <div class="container is-max-desktop">
-    <h2 class="title is-3 has-text-centered">Contact & Acknowledgments</h2>
+    <h2 class="title is-3 has-text-centered">Acknowledgments</h2>
 
     <div class="content">
       <div class="feature-box">
-        <h4 class="title is-5">Acknowledgments</h4>
         <p style="text-align: justify;">
           This research was supported by the <strong>National Science Foundation</strong> under Grant No. <strong>2020751</strong>,
           as well as by the <strong>Alfred P. Sloan Foundation</strong> through the OSPO for UC initiative
           (Award No. <strong>2024-22424</strong>).
         </p>
       </div>
+    </div>
+  </div>
+</section>
 
+<section class="section" id="contact">
+  <div class="container is-max-desktop">
+    <h2 class="title is-3 has-text-centered">Contact</h2>
+
+    <div class="content">
       <div class="feature-box">
-        <h4 class="title is-5">Contact</h4>
         <p style="text-align: center;">
           RepoWise is developed by the <a href="https://decallab.cs.ucdavis.edu/" target="_blank"><strong>DECAL Lab</strong></a>
           at UC Davis.


### PR DESCRIPTION
## Summary
- split the combined contact and acknowledgments content into two dedicated sections
- preserve existing acknowledgments and contact details with clearer headings and anchors

## Testing
- Not run (not requested)