### PR TITLE
Configure view counter backend base URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="description" content="RepoWise: AI-Powered OSS Documentation Assistant">
   <meta name="keywords" content="OSS, AI, RAG, Open Source, Documentation">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="ossprey-view-counter-api-base" content="https://tianna-unretractive-ellen.ngrok-free.dev">
   <title>RepoWise - Where OSS Exploration Begins</title>
 
   <link href="https://fonts.googleapis.com/css?family=Google+Sans|Noto+Sans|Castoro" rel="stylesheet">


### PR DESCRIPTION
## Summary
- set a meta tag declaring the view counter API base so requests target the provided backend

## Testing
- not run (not requested)