### PR TITLE
Add RepoWise user count display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1015,6 +1015,7 @@ npm run dev</code></pre>
     <div class="box has-text-centered">
       <h2 class="title is-5" style="margin-bottom: 0.5em;">User Analytics</h2>
       <p class="is-size-5">RepoWise Views: <span id="view-count" class="tag is-link is-light is-medium">...</span></p>
+      <p class="is-size-5" style="margin-top: 0.75em;">RepoWise Users: <span id="user-count" class="tag is-info is-light is-medium">...</span></p>
     </div>
   </div>
 </section>
@@ -1032,6 +1033,7 @@ npm run dev</code></pre>
   </div>
 </footer>
 
+<script src="./static/js/user-count.js"></script>
 <script src="./static/js/view-counter.js"></script>
 
 </body>

--- a/static/js/user-count.js
+++ b/static/js/user-count.js
@@ -1,0 +1,59 @@
+const USER_COUNT_ENDPOINT = 'https://tianna-unretractive-ellen.ngrok-free.dev/api/auth/users/count';
+
+function updateUserCountElement(value) {
+  const element = document.getElementById('user-count');
+  if (!element) {
+    return;
+  }
+  element.textContent = value;
+}
+
+async function parseUserCountResponse(response) {
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    const data = await response.json();
+    if (typeof data === 'number') {
+      return data;
+    }
+    if (data && typeof data.count === 'number') {
+      return data.count;
+    }
+    const numericValue = Object.values(data).find((value) => typeof value === 'number');
+    if (typeof numericValue === 'number') {
+      return numericValue;
+    }
+  }
+
+  const fallbackText = await response.text();
+  const parsed = parseInt(fallbackText, 10);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+
+  throw new Error('Unable to parse user count from response.');
+}
+
+async function fetchUserCount() {
+  const element = document.getElementById('user-count');
+  if (!element) {
+    return;
+  }
+
+  try {
+    updateUserCountElement('...');
+    const response = await fetch(USER_COUNT_ENDPOINT, { mode: 'cors' });
+    if (!response.ok) {
+      throw new Error(`User count request failed with status ${response.status}`);
+    }
+    const count = await parseUserCountResponse(response);
+    updateUserCountElement(count.toLocaleString());
+  } catch (error) {
+    console.error('Failed to fetch RepoWise user count', error);
+    updateUserCountElement('N/A');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchUserCount();
+});


### PR DESCRIPTION
## Summary
- add RepoWise user count alongside existing analytics section at the bottom of the page
- fetch the registered user total from the provided backend endpoint with graceful fallback handling

## Testing
- not run (static changes)