### PR TITLE
Add processed repository count analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1173,6 +1173,12 @@ npm run dev</code></pre>
             <span id="user-count" class="tag is-info is-light is-medium">...</span>
           </p>
         </div>
+        <div class="column is-narrow">
+          <p class="is-size-5">
+            Processed Repositories:
+            <span id="processed-repo-count" class="tag is-primary is-light is-medium">...</span>
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -1194,6 +1200,7 @@ npm run dev</code></pre>
 
 <script src="./static/js/user-count.js"></script>
 <script src="./static/js/view-counter.js"></script>
+<script src="./static/js/processed-repo-count.js"></script>
 <script>
   const yearElement = document.getElementById("current-year");
   if (yearElement) {

--- a/static/js/processed-repo-count.js
+++ b/static/js/processed-repo-count.js
@@ -1,0 +1,59 @@
+const PROCESSED_REPO_COUNT_ENDPOINT = '/api/processed-repo-count';
+
+function updateProcessedRepoCountElement(value) {
+  const element = document.getElementById('processed-repo-count');
+  if (!element) {
+    return;
+  }
+  element.textContent = value;
+}
+
+async function parseProcessedRepoCountResponse(response) {
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    const data = await response.json();
+    if (typeof data === 'number') {
+      return data;
+    }
+    if (data && typeof data.count === 'number') {
+      return data.count;
+    }
+    const numericValue = Object.values(data).find((value) => typeof value === 'number');
+    if (typeof numericValue === 'number') {
+      return numericValue;
+    }
+  }
+
+  const fallbackText = await response.text();
+  const parsed = parseInt(fallbackText, 10);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+
+  throw new Error('Unable to parse processed repository count from response.');
+}
+
+async function fetchProcessedRepoCount() {
+  const element = document.getElementById('processed-repo-count');
+  if (!element) {
+    return;
+  }
+
+  try {
+    updateProcessedRepoCountElement('...');
+    const response = await fetch(PROCESSED_REPO_COUNT_ENDPOINT, { mode: 'cors' });
+    if (!response.ok) {
+      throw new Error(`Processed repo count request failed with status ${response.status}`);
+    }
+    const count = await parseProcessedRepoCountResponse(response);
+    updateProcessedRepoCountElement(count.toLocaleString());
+  } catch (error) {
+    console.error('Failed to fetch processed repository count', error);
+    updateProcessedRepoCountElement('N/A');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchProcessedRepoCount();
+});


### PR DESCRIPTION
## Summary
- add a processed repository metric alongside existing user analytics on the landing page
- create a script to fetch and render the processed repository count from `/api/processed-repo-count`

## Testing
- Not run (not requested)